### PR TITLE
Support automatic fetching of credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ var es = require('elasticsearch').Client({
   }
 });
 ```
+
+Pre-configured credentials can be fetched automatically (through AWS's `getCredentials` function) by specifying `getCredentials: true` in the `amazonES` object in place of `accessKey` and `secretKey`.

--- a/connector-es6.js
+++ b/connector-es6.js
@@ -22,7 +22,7 @@
  */
 
 let AWS = require('aws-sdk');
-let HttpConnector = require('elasticsearch/src/lib/connectors/http')
+let HttpConnector = require('elasticsearch/src/lib/connectors/http');
 let _ = require('elasticsearch/src/lib/utils');
 let zlib = require('zlib');
 
@@ -89,7 +89,7 @@ class HttpAmazonESConnector extends HttpConnector {
     signer.addAuthorization(this.creds, new Date());
 
     var send = new AWS.NodeHttpClient();
-    var req = send.handleRequest(request, null, function (_incoming) {
+    req = send.handleRequest(request, null, function (_incoming) {
       incoming = _incoming;
       status = incoming.statusCode;
       headers = incoming.headers;

--- a/connector-es6.js
+++ b/connector-es6.js
@@ -31,7 +31,13 @@ class HttpAmazonESConnector extends HttpConnector {
     super(host, config);
     this.endpoint = new AWS.Endpoint(host.host);
     let c = config.amazonES;
-    this.creds = new AWS.Credentials(c.accessKey, c.secretKey);
+    if (c.getCredentials) {
+      AWS.config.getCredentials(() => {
+        this.creds = AWS.config.credentials;
+      });
+    } else {
+      this.creds = new AWS.Credentials(c.accessKey, c.secretKey);
+    }
     this.amazonES = c;
   }
 


### PR DESCRIPTION
Due to the async nature of AWS's `getCredentials`, it can be cumbersome to use it before passing credentials to the elasticsearch client constructor, if a client object is immediately desired. This PR solves this through the use of a new configuration parameter `getCredentials` that can be set on the `amazonES` object.

Thanks for this package, by the way! It helped me out a lot!
