### PR TITLE
Support passing in user provided credentials object

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,18 @@ var es = require('elasticsearch').Client({
   }
 });
 ```
+
+Alternatively you can pass in your own [AWS Credentials object](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Credentials.html).
+This is particularly useful if running on AWS Lambda, since the appropriate credentials are already in the environment.
+
+```javascript
+var myCredentials = new AWS.EnvironmentCredentials('AWS'); // Lambda provided credentials
+var es = require('elasticsearch').Client({
+  hosts: 'https://amazon-es-host.us-east-1.es.amazonaws.com',
+  connectionClass: require('http-aws-es'),
+  amazonES: {
+    region: "us-east-1",
+    credentials: myCredentials
+  }
+});
+```

--- a/connector-es6.js
+++ b/connector-es6.js
@@ -11,7 +11,8 @@
  *  amazonES: {
  *    region: 'us-east-1',
  *    accessKey: 'AKID',
- *    secretKey: 'secret'
+ *    secretKey: 'secret',
+ *    credentials: new AWS.EnvironmentCredentials('AWS') // Optional
  *  }
  * });
  *
@@ -31,7 +32,11 @@ class HttpAmazonESConnector extends HttpConnector {
     super(host, config);
     this.endpoint = new AWS.Endpoint(host.host);
     let c = config.amazonES;
-    this.creds = new AWS.Credentials(c.accessKey, c.secretKey);
+    if (c.credentials) {
+      this.creds = c.credentials;
+    } else {
+      this.creds = new AWS.Credentials(c.accessKey, c.secretKey);
+    }
     this.amazonES = c;
   }
 


### PR DESCRIPTION
If you're calling elasticsearch from AWS Lambda, the appropriate credentials and role are already provided in the environment, so there is no need to manually specify them or fetch them as in #1.

This allows the user to pass any credentials object, so it will likely meet other use cases.