### PR TITLE
Enable proxy use and other httpOptions goodness, Extract aws-sdk configuration from SDK if not provided.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@ Connection handler for Amazon ES
 ---
 
 Makes elasticsearch-js compatible with Amazon ES. It uses the aws-sdk to make signed requests to an Amazon ES endpoint.
+
+The configuration for signing the request can be explicitly provided.  Otherwise, it will be extracted from the `aws-sdk` configuration.
+
+Use the `aws-sdk` configuration:
+```javascript
+var es = require('elasticsearch').Client({
+  hosts: 'https://amazon-es-host.us-east-1.es.amazonaws.com',
+  connectionClass: require('http-aws-es')
+});
+```
+
 Define the Amazon ES config and the connection handler
 in the client configuration:
 
@@ -12,7 +23,8 @@ var es = require('elasticsearch').Client({
   amazonES: {
     region: 'us-east-1',
     accessKey: 'AKID',
-    secretKey: 'secret'
+    secretKey: 'secret',
+    httpOptions: myHttpOptions
   }
 });
 ```
@@ -26,8 +38,9 @@ var es = require('elasticsearch').Client({
   hosts: 'https://amazon-es-host.us-east-1.es.amazonaws.com',
   connectionClass: require('http-aws-es'),
   amazonES: {
-    region: "us-east-1",
-    credentials: myCredentials
+    region: 'us-east-1',
+    credentials: myCredentials,
+    httpOptions: myHttpOptions
   }
 });
 ```

--- a/connector-es6.js
+++ b/connector-es6.js
@@ -8,11 +8,12 @@
  * var es = require('elasticsearch').Client({
  *  hosts: 'https://amazon-es-host.us-east-1.es.amazonaws.com',
  *  connectionClass: require('http-aws-es'),
- *  amazonES: {
- *    region: 'us-east-1',
- *    accessKey: 'AKID',
- *    secretKey: 'secret',
+ *  amazonES: {                                          // Optional
+ *    region: 'us-east-1',                               // Optional
+ *    accessKey: 'AKID',                                 // Optional
+ *    secretKey: 'secret',                               // Optional
  *    credentials: new AWS.EnvironmentCredentials('AWS') // Optional
+ *    httpOptions: myHttpOptions                         // Optional, see AWS.config.httpOptions
  *  }
  * });
  *
@@ -31,13 +32,33 @@ class HttpAmazonESConnector extends HttpConnector {
   constructor(host, config) {
     super(host, config);
     this.endpoint = new AWS.Endpoint(host.host);
-    let c = config.amazonES;
-    if (c.credentials) {
-      this.creds = c.credentials;
+    this.region = this.getRegion(config.amazonES);
+    this.creds = this.getCredentials(config.amazonES);
+    this.httpOptions = this.getHttpOptions(config.amazonES);
+  }
+
+  getRegion(amazonES) {
+    if (amazonES && amazonES.region) {
+      return amazonES.region;
     } else {
-      this.creds = new AWS.Credentials(c.accessKey, c.secretKey);
+      return AWS.config.region;
     }
-    this.amazonES = c;
+  }
+  getCredentials(amazonES) {
+    if (amazonES && amazonES.credentials) {
+      return amazonES.credentials;
+    } else if(amazonES && amazonES.accessKey && amazonES.secretKey) {
+      return new AWS.Credentials(amazonES.accessKey, amazonES.secretKey);
+    } else {
+      return AWS.config.credentials;
+    }
+  }
+  getHttpOptions() {
+    if(amazonES && amazonES.httpOptions) {
+      return amazonES.httpOptions;
+    } else {
+      return AWS.config.httpOptions;
+    }
   }
 
   request(params, cb) {
@@ -77,7 +98,7 @@ class HttpAmazonESConnector extends HttpConnector {
     for (let p in reqParams) {
       request[p] = reqParams[p];
     }
-    request.region = this.amazonES.region;
+    request.region = this.region;
     if (params.body) request.body = params.body;
     if (!request.headers) request.headers = {};
     request.headers['presigned-expires'] = false;
@@ -88,7 +109,7 @@ class HttpAmazonESConnector extends HttpConnector {
     signer.addAuthorization(this.creds, new Date());
 
     var send = new AWS.NodeHttpClient();
-    req = send.handleRequest(request, AWS.config.httpOptions, function (_incoming) {
+    req = send.handleRequest(request, this.httpOptions, function (_incoming) {
       incoming = _incoming;
       status = incoming.statusCode;
       headers = incoming.headers;

--- a/connector-es6.js
+++ b/connector-es6.js
@@ -53,7 +53,7 @@ class HttpAmazonESConnector extends HttpConnector {
       return AWS.config.credentials;
     }
   }
-  getHttpOptions() {
+  getHttpOptions(amazonES) {
     if(amazonES && amazonES.httpOptions) {
       return amazonES.httpOptions;
     } else {

--- a/connector-es6.js
+++ b/connector-es6.js
@@ -88,7 +88,7 @@ class HttpAmazonESConnector extends HttpConnector {
     signer.addAuthorization(this.creds, new Date());
 
     var send = new AWS.NodeHttpClient();
-    req = send.handleRequest(request, null, function (_incoming) {
+    req = send.handleRequest(request, AWS.config.httpOptions, function (_incoming) {
       incoming = _incoming;
       status = incoming.statusCode;
       headers = incoming.headers;


### PR DESCRIPTION
Replace null with the httpOptions object that aws-sdk is configured with.  As per the sdk, handleRequest requires those be passed in.  This allows the use of proxies via agent and other httpOptions goodness.
