### PR TITLE
Enable connection on port other than 443

### DIFF
--- a/connector-es6.js
+++ b/connector-es6.js
@@ -30,7 +30,12 @@ let zlib = require('zlib');
 class HttpAmazonESConnector extends HttpConnector {
   constructor(host, config) {
     super(host, config);
-    this.endpoint = new AWS.Endpoint(host.host);
+    if (!('protocol' in host) || !('port' in host)) {
+      this.endpoint = new AWS.Endpoint(host.host);
+    } else {
+      var endpointUrl = host.protocol + '://' + host.host + ':' + host.port;
+      this.endpoint = new AWS.Endpoint(endpointUrl);
+    }
     let c = config.amazonES;
     if (c.credentials) {
       this.creds = c.credentials;


### PR DESCRIPTION
Right now, the port and protocol fields specified in hosts as suggested by https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/host-reference.html are ignored. By constructing the endpoint URL using protocol, port and host, the connector class can be used to connect to Elasticsearch instances which are not running on 443 port.
