### PR TITLE
Support a promise being passed to amazonES credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,19 @@
     "aws-sdk": "^2.2.19"
   },
   "devDependencies": {
-    "babel": "^5.8.23",
-    "babel-eslint": "^4.1.3",
+    "babel-cli": "^6.7.5",
+    "babel-eslint": "^6.0.2",
+    "babel-preset-es2015": "^6.6.0",
     "eslint": "^1.7.1"
   },
   "scripts": {
     "prepublish": "babel ./connector-es6.js > ./connector.js",
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
   },
   "author": "Geoff Wagstaff <geoff@gosquared.com>",
   "license": "MIT"


### PR DESCRIPTION
This is useful if you want to leverage AWS.CredentialProviderChain to
determine the credentials that should be used.

ie.

```
function credentials() {
  return new Promise((resolve, reject) => {
    const provider = new AWS.CredentialProviderChain();
    provider.resolve((err, creds) => {
      if (err) return reject(err);
      resolve(creds);
    });
  });
}

export default new Client({
  connectionClass: connector,
  amazonES: {
    region: process.env.AWS_REGION,
    credentials: credentials(),
  },
});
```
