### PR TITLE
Add support for AWS.Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@ Connection handler for Amazon ES
 ---
 
 Makes elasticsearch-js compatible with Amazon ES. It uses the aws-sdk to make signed requests to an Amazon ES endpoint.
-Define the Amazon ES config and the connection handler
-in the client configuration:
+Define the Amazon ES config and the connection handler in the client configuration.
+
+Configure the AWS Config according to aws-sdk,
+which allows using environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION.
 
 ```javascript
+AWS.config.update({
+  region: 'us-east-1', accessKeyId: 'AKID', secretAccessKey: 'secret'
+});
+
 var es = require('elasticsearch').Client({
   hosts: 'https://amazon-es-host.us-east-1.es.amazonaws.com',
   connectionClass: require('http-aws-es'),
-  amazonES: {
-    region: 'us-east-1',
-    accessKey: 'AKID',
-    secretKey: 'secret'
-  }
+  amazonES: AWS.config
 });
 ```


### PR DESCRIPTION
The AWS SDK has a configuration object that is very close to the amazonES object 
(region and credentials same, but not accessKey and secretKey).

Switching to using AWS.config as amazonES allows using standard AWS SDK setup.

This includes only using getCredentials on AWS.config, matching behavior of AWS SDK,
which handles the provider chain (environment variables, EC2 metadata) and credentials refresh.
