### PR TITLE
Add keep alive parameter

### DIFF
--- a/connector-es6.js
+++ b/connector-es6.js
@@ -49,6 +49,7 @@ class HttpAmazonESConnector extends HttpConnector {
     var headers = {};
     var log = this.log;
     var response;
+    var keepAlive = params.keepAlive === undefined ? true : !!params.keepAlive;
 
     var reqParams = this.makeReqParams(params);
     // general clean-up procedure to run after the request
@@ -111,7 +112,7 @@ class HttpAmazonESConnector extends HttpConnector {
     req.on('error', cleanUp);
 
     req.setNoDelay(true);
-    req.setSocketKeepAlive(true);
+    req.setSocketKeepAlive(keepAlive);
 
     return function () {
       req.abort();


### PR DESCRIPTION
There is kept connection alive (actually, I don't know what it's a purpose here if this connection is not reused anyway), so as first step I added `keepAlive` parameter which is by default `true` to keep backward compatibility.

The biggest problem is when you make a lot of requests to ES - you still have all connections from before, so after connections pool is full, "No Living connections" error will be thrown from ElasticSearch.