### PR TITLE
Made the package work for node 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
+'use strict';
 let nodeMajor = process.version.match(/([0-9]+)\./)[1];
 
 if (nodeMajor < 4) {
   module.exports = require('./legacy');
 } else if (nodeMajor.match(/4|6|8/)) {
+  require("regenerator-runtime/runtime");
   module.exports = require('./node'+nodeMajor);
 } else {
   module.exports = require('./node8');

--- a/index.js
+++ b/index.js
@@ -3,8 +3,10 @@ let nodeMajor = process.version.match(/([0-9]+)\./)[1];
 
 if (nodeMajor < 4) {
   module.exports = require('./legacy');
-} else if (nodeMajor.match(/4|6|8/)) {
+} else if (nodeMajor.match(/4/)) {
   require("regenerator-runtime/runtime");
+  module.exports = require('./node'+nodeMajor);
+} else if (nodeMajor.match(/6|8/)) {
   module.exports = require('./node'+nodeMajor);
 } else {
   module.exports = require('./node8');

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "build-legacy": "BABEL_ENV=legacy babel ./connector.js -o ./legacy.js"
   },
   "author": "Geoff Wagstaff <geoff@gosquared.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "regenerator-runtime": "^0.10.5"
+  }
 }


### PR DESCRIPTION
Hello,

When running the http-aws-es package with node 4 we got the following errors:

`(function (exports, require, module, __filename, __dirname) { let nodeMajor = process.version.match(/([0-9]+)\./)[1];
                                                              ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/path-to-file.js:5:19)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)`

And also, when resolving the error above:

      var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee(params, cb) {
                                   ^

ReferenceError: regeneratorRuntime is not defined
    at /Users/marcusandersson/Development/tiptapp/api/node_modules/http-aws-es/node4.js:65:36
    at /Users/marcusandersson/Development/tiptapp/api/node_modules/http-aws-es/node4.js:173:6
    at Object.<anonymous> (/Users/marcusandersson/Development/tiptapp/api/node_modules/http-aws-es/node4.js:190:2)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/node_modules/http-aws-es/index.js:8:20)

We resolved it by adding the 'use strict' statement and also adding the regenerator runtime if running in node 4. Hope this feels like a reasonable solution.

Thanks!