### PR TITLE
Always set the Content-Length header for requests with a body

### DIFF
--- a/dist/connector.js
+++ b/dist/connector.js
@@ -124,7 +124,10 @@ var HttpAmazonESConnector = function (_HttpConnector) {
                   request[p] = reqParams[p];
                 }
                 request.region = this.awsConfig.region;
-                if (params.body) request.body = params.body;
+                if (params.body) {
+                  request.body = params.body;
+                  request.headers['Content-Length'] = params.body.length;
+                }
                 if (!request.headers) request.headers = {};
                 request.headers['presigned-expires'] = false;
                 request.headers['Host'] = this.endpoint.host;


### PR DESCRIPTION
AWS  requires the Content-Length header when the body is sent, otherwise the request signature will not match.
Elasticsearch.js does not set a Content-Length header for request bodies of DELETE requests.
Since this is a requirement for requests to AWS, the connector should take up that responsibility.

Fixes https://github.com/TheDeveloper/http-aws-es/issues/19