### PR TITLE
Depend on elasticsearch-js 14.2.0 instead of 13.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.0
+* Depends on Elasticsearch-js 14.2.0 instead of 13.2.0 [#49][49]
+
 ### 4.0.0
 * Use AWS XHRClient in browser. [#42][42]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,10 +57,13 @@
       }
     },
     "agentkeepalive": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
-      "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8=",
-      "dev": true
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.4.1.tgz",
+      "integrity": "sha512-MPIwsZU9PP9kOrZpyu2042kYA8Fdt/AedQYkYXucHgF9QoD9dXVp0ypuGnHXSR0hTstBxdt85Xkh4JolYfK5wg==",
+      "dev": true,
+      "requires": {
+        "humanize-ms": "1.2.1"
+      }
     },
     "ajv": {
       "version": "5.2.4",
@@ -954,12 +957,12 @@
       "dev": true
     },
     "elasticsearch": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-13.3.1.tgz",
-      "integrity": "sha1-xTCuqa+xfqkcPQpW8fERukm8kjk=",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-14.2.0.tgz",
+      "integrity": "sha1-73xuUFy0FSWgdRtRVujA+9HwLWI=",
       "dev": true,
       "requires": {
-        "agentkeepalive": "2.2.0",
+        "agentkeepalive": "3.4.1",
         "chalk": "1.1.3",
         "lodash": "2.4.2",
         "lodash.get": "4.4.2",
@@ -1577,6 +1580,15 @@
             "ms": "2.0.0"
           }
         }
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
       }
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "main": "connector.js",
   "peerDependencies": {
     "aws-sdk": "^2.138.0",
-    "elasticsearch": "^13.2.0"
+    "elasticsearch": "^14.2.0"
   },
   "devDependencies": {
     "aws-sdk": "^2.138.0",
     "browserify": "^14.5.0",
     "chai": "^4.1.2",
-    "elasticsearch": "^13.3.1",
+    "elasticsearch": "^14.2.0",
     "eslint": "^4.9.0",
     "express": "^4.16.2",
     "minimist": "^1.2.0",


### PR DESCRIPTION
Fixes https://github.com/TheDeveloper/http-aws-es/issues/49
=> Updates version number to 5.0.0