### PR TITLE
sessionToken Example for usage with AWS Cognito

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ AWS.config.update({
 
 ## Region + Credentials + SessionToken
 The connector uses aws-sdk's default behaviour to obtain region + credentials from your environment. If you would like to set these manually, you can set them on aws-sdk. This example uses a sessionToken together with accessKey and secret. This way you can also auth against temporary credentials provided by
-AWS Cognito. Means, you can access ES with the Cognito Federated Entities authRole of the loggedIn User. 
+AWS Cognito. Means, you can access ES with the Cognito Federated Identities authRole of the loggedIn User. 
 
 ```javascript
 let AWS = require('aws-sdk');
@@ -37,6 +37,28 @@ AWS.config.update({
   credentials: new AWS.Credentials(accessKeyId, secretAccessKey, sessionToken),
   region: 'us-east-1'
 });
+```
+
+Example access policy for ES usage with auth Role from Cognito Federated Identities. Additionally added a user for postman to see the difference
+between user and role policies.
+
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::xxxxxxxxxxxx:role/appAuthRole",
+          "arn:aws:iam::xxxxxxxxxxxx:user/espostman"
+        ]
+      },
+      "Action": "es:*",
+      "Resource": "arn:aws:es:<REGION>:<ACCOUNT>:domain/foobar/*"
+    }
+  ]
+}
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ AWS.config.update({
 });
 ```
 
+## Region + Credentials + SessionToken
+The connector uses aws-sdk's default behaviour to obtain region + credentials from your environment. If you would like to set these manually, you can set them on aws-sdk. This example uses a sessionToken together with accessKey and secret. This way you can also auth against temporary credentials provided by
+AWS Cognito. Means, you can access ES with the Cognito Federated Entities authRole of the loggedIn User. 
+
+```javascript
+let AWS = require('aws-sdk');
+AWS.config.update({
+  credentials: new AWS.Credentials(accessKeyId, secretAccessKey, sessionToken),
+  region: 'us-east-1'
+});
+```
+
 ## Options
 ```javascript
 let options = {


### PR DESCRIPTION
This PR enhances documentation for usage with authRoles from loggedIn User when using AWS Cognito federated identities.

Makes it easier for users to use this library without scanning the AWS.Credentials class.