### PR TITLE
Only require the core libraries of aws-sdk

### DIFF
--- a/connector.js
+++ b/connector.js
@@ -11,7 +11,7 @@
  * @class HttpConnector
  */
 
-const AWS = require('aws-sdk');
+const AWS = require('aws-sdk/lib/core');
 const HttpConnector = require('elasticsearch/src/lib/connectors/http');
 const HttpClient = require('./src/node');
 

--- a/src/node.js
+++ b/src/node.js
@@ -1,4 +1,4 @@
-const AWS = require('aws-sdk');
+const AWS = require('aws-sdk/lib/core');
 const zlib = require('zlib');
 
 class NodeHttpClient {


### PR DESCRIPTION
Only include the library files from `aws-sdk` rather than the whole module. This means module bundler tools like webpack can tree shake the API JSON files of unused services when including `http-aws-es` as a dependency. Doing so can massively reduce bundle size of dependents.

Following advice from AWS's documentation on webpack: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/webpack.html