### PR TITLE
Being able to specify a specific host for Signing the request

### DIFF
--- a/connector.js
+++ b/connector.js
@@ -28,6 +28,8 @@ class HttpAmazonESConnector extends HttpConnector {
 
     this.awsConfig = config.awsConfig || AWS.config;
     this.endpoint = endpoint;
+    this.signatureHost = config.signatureHost;
+
     this.httpOptions = config.httpOptions || this.awsConfig.httpOptions;
     this.httpClient = new HttpClient();
   }
@@ -62,6 +64,7 @@ class HttpAmazonESConnector extends HttpConnector {
         const request = this.createRequest(params, reqParams);
         // Sign the request (Sigv4)
         this.signRequest(request, creds);
+        request.headers['Host'] = this.endpoint.host;
         req = this.httpClient.handleRequest(request, this.httpOptions, done);
       })
       .catch(done);
@@ -95,7 +98,7 @@ class HttpAmazonESConnector extends HttpConnector {
       request.headers['Content-Length'] = contentLength;
       request.body = body;
     }
-    request.headers['Host'] = this.endpoint.host;
+    request.headers['Host'] = this.signatureHost || this.endpoint.host;
 
     return request;
   }


### PR DESCRIPTION
When ElasticSearch is below a VPC, there is a way to access it externally using an Nginx proxy as per AWS Documentation (https://docs.amazonaws.cn/en_us/elasticsearch-service/latest/developerguide/es-kibana.html).

If you try to sign the request using the Proxy host, it will fail as it's expecting the original ES Endpoint, I have managed to add a parameter to the ES client in order to specify the host it should be used for the signature.

You can pass an extra parameter to the ES Client:
```
signatureHost: 'XXXX',
```